### PR TITLE
Release v2.0.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: install talisman
         run: |
-          sudo curl -sLo /usr/local/bin/talisman https://github.com/thoughtworks/talisman/releases/download/v1.23.0/talisman_linux_amd64
+          sudo curl -sLo /usr/local/bin/talisman https://github.com/thoughtworks/talisman/releases/download/v1.27.0/talisman_linux_amd64
           sudo chmod 0755 /usr/local/bin/talisman
       - name: Install terraform-docs
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,13 @@ repos:
         exclude: cloud-config\.ya?ml$
         entry: yamllint --strict
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.71.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
         args: ['--args=--sort-by=required --hide=providers']
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
@@ -26,6 +26,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/thoughtworks/talisman
-    rev: v1.23.0
+    rev: v1.26.0
     hooks:
       - id: talisman-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2022-05-05
+
+This release updates the wrapped Google Bastion module to track v5.x, and includes
+a breaking variable change from that module.
+
+### Added
+
+### Changed
+
+- mirror upstream bastion module variable name change; `ephemeral_ip` is now
+  `external_ip`
+- pin `forward-proxy` base container to `alpine:3.15.4`
+
+### Removed
+
 ## [1.0.0] - 2022-02-16
 
 Initial public release of module.
 
-## Added
+### Added
 
-## Changed
+### Changed
 
-## Removed
+### Removed
 
-<!--
-[1.0.1]: https://github.com/memes/terraform-google-private-bastion/compare/v1.0.0...v1.0.1
--->
+[2.0.0]: https://github.com/memes/terraform-google-private-bastion/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/memes/terraform-google-private-bastion/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ as you have authenticated to the target repository.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_bastion"></a> [bastion](#module\_bastion) | terraform-google-modules/bastion-host/google | 4.1.0 |
+| <a name="module_bastion"></a> [bastion](#module\_bastion) | terraform-google-modules/bastion-host/google | 5.0.0 |
 
 ## Resources
 
@@ -195,7 +195,7 @@ as you have authenticated to the target repository.
 | <a name="input_additional_ports"></a> [additional\_ports](#input\_additional\_ports) | A list of additional TCP ports that will be allowed to receive IAP tunneled<br>traffic. Default is [8888] to allow for forward-proxy use-case. | `list(number)` | <pre>[<br>  8888<br>]</pre> | no |
 | <a name="input_bastion_targets"></a> [bastion\_targets](#input\_bastion\_targets) | An optional set of firewall targets that will be used to create GCP Firewall Rules<br>that allow the targets to receive _ALL_ ingress traffic from the bastion instance.<br>Targets are specified as a list of service account emails, destination CIDRs, and<br>target network tags. If a priority is unspecified, the rules will be created at<br>the default priority (1000).<br><br>Leave this variable at the default empty value to manage firewall rules outside<br>this module. | <pre>object({<br>    service_accounts = list(string)<br>    cidrs            = list(string)<br>    tags             = list(string)<br>    priority         = number<br>  })</pre> | <pre>{<br>  "cidrs": null,<br>  "priority": null,<br>  "service_accounts": null,<br>  "tags": null<br>}</pre> | no |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | The size of the bastion boot disk in GB. Default is 20. | `number` | `20` | no |
-| <a name="input_ephemeral_ip"></a> [ephemeral\_ip](#input\_ephemeral\_ip) | Boolean flag to toggle provisioning of an ephemeral public IP on the bastion<br>instance; default is false. | `bool` | `false` | no |
+| <a name="input_external_ip"></a> [external\_ip](#input\_external\_ip) | Boolean flag to toggle provisioning of an ephemeral public IP on the bastion<br>instance; default is false. | `bool` | `false` | no |
 | <a name="input_image"></a> [image](#input\_image) | Specifies the image family and project id to use for bastion. Default will launch<br>the latest stable COS image with Confidential VM support. | <pre>object({<br>    family     = string<br>    project_id = string<br>  })</pre> | <pre>{<br>  "family": "cos-stable",<br>  "project_id": "confidential-vm-images"<br>}</pre> | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | An optional map of labels to apply to resources created by this module, in addition<br>to those always set. Default is empty. | `map(string)` | `{}` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The Compute Engine machine type to use for bastion. Default is 'e2-medium'. | `string` | `"e2-medium"` | no |

--- a/containers/forward-proxy/Dockerfile
+++ b/containers/forward-proxy/Dockerfile
@@ -1,5 +1,5 @@
 # Run tinyproxy in forward only mode
-FROM alpine:3.15
+FROM alpine:3.15.4
 LABEL maintainer="Matthew Emes <memes@matthewemes.com>"
 
 RUN apk --no-cache add tinyproxy=1.11.0-r0 ca-certificates=20211220-r0

--- a/examples/quick-start/README.md
+++ b/examples/quick-start/README.md
@@ -128,7 +128,7 @@ external traffic through the NAT then a pull from Docker Hub or GHCR will work.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_bastion"></a> [bastion](#module\_bastion) | memes/private-bastion/google | 1.0.0 |
+| <a name="module_bastion"></a> [bastion](#module\_bastion) | memes/private-bastion/google | 2.0.0 |
 
 ## Resources
 

--- a/examples/quick-start/main.tf
+++ b/examples/quick-start/main.tf
@@ -15,7 +15,7 @@ provider "google" {
 
 module "bastion" {
   source                = "memes/private-bastion/google"
-  version               = "1.0.0"
+  version               = "2.0.0"
   proxy_container_image = var.proxy_container_image
   prefix                = var.prefix
   project_id            = var.project_id

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ data "google_compute_subnetwork" "subnet" {
 
 module "bastion" {
   source                     = "terraform-google-modules/bastion-host/google"
-  version                    = "4.1.0"
+  version                    = "5.0.0"
   service_account_name       = local.bastion_name
   name                       = local.bastion_name
   name_prefix                = local.bastion_name
@@ -46,7 +46,7 @@ module "bastion" {
   image_project              = var.image.project_id
   labels                     = local.labels
   tags                       = local.tags
-  ephemeral_ip               = var.ephemeral_ip
+  external_ip                = var.external_ip
   metadata = {
     user-data = templatefile("${path.module}/templates/cloud-config.yaml", {
       docker_credential_registries = distinct(concat(

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ the latest stable COS image with Confidential VM support.
 EOD
 }
 
-variable "ephemeral_ip" {
+variable "external_ip" {
   type        = bool
   default     = false
   description = <<-EOD


### PR DESCRIPTION
- update wrapped Google bastion module to v5.0.0
- explicitly set forward-proxy container to be based on `alpine:3.15.4`