### PR TITLE
Fix: Update forward-proxy to Alpine 3.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2023-01-02
+
+### Added
+
+### Changed
+
+- Updated `forward-proxy` container to use Alpine 3.17.0, and Tinyproxy 1.11.1-r2
+
+### Removed
+
 ## [2.2.0] - 2023-01-02
 
 ### Added
@@ -18,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that defines a `gcloud` operation to start an IAP tunnel that forwards connections
   made to localhost:local_port through the tunnel. Default value is 8888 for
   backward compatibility.
+
+### Changed
+
+### Removed
 
 ## [2.1.0] - 2022-11-19
 
@@ -76,6 +90,7 @@ Initial public release of module.
 
 ### Removed
 
+[2.2.1]: https://github.com/memes/terraform-google-private-bastion/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/memes/terraform-google-private-bastion/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/memes/terraform-google-private-bastion/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/memes/terraform-google-private-bastion/compare/v2.0.1...v2.0.2

--- a/containers/forward-proxy/Dockerfile
+++ b/containers/forward-proxy/Dockerfile
@@ -1,8 +1,8 @@
 # Run tinyproxy in forward only mode
-FROM alpine:3.16.3
+FROM alpine:3.17.0
 LABEL maintainer="Matthew Emes <memes@matthewemes.com>"
 
-RUN apk --no-cache add tinyproxy=1.11.0-r0 ca-certificates=20220614-r0
+RUN apk --no-cache add tinyproxy=1.11.1-r2 ca-certificates=20220614-r3
 EXPOSE 8888
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
 USER nobody

--- a/examples/quick-start/README.md
+++ b/examples/quick-start/README.md
@@ -128,7 +128,7 @@ external traffic through the NAT then a pull from Docker Hub or GHCR will work.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_bastion"></a> [bastion](#module\_bastion) | memes/private-bastion/google | 2.2.0 |
+| <a name="module_bastion"></a> [bastion](#module\_bastion) | memes/private-bastion/google | 2.2.1 |
 
 ## Resources
 

--- a/examples/quick-start/main.tf
+++ b/examples/quick-start/main.tf
@@ -15,7 +15,7 @@ provider "google" {
 
 module "bastion" {
   source                = "memes/private-bastion/google"
-  version               = "2.2.0"
+  version               = "2.2.1"
   proxy_container_image = var.proxy_container_image
   prefix                = var.prefix
   project_id            = var.project_id


### PR DESCRIPTION
Use Alpine 3.17.0 as the base container for forward-proxy, and update Tinyproxy to latest.