### PR TITLE
Remove Google bastion module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
       interval: "weekly"
     reviewers:
       - memes
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - memes
   - package-ecosystem: "terraform"
     directory: "/"
     schedule:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,9 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches-ignore:
+      - main
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,15 +19,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: install talisman
         run: |
-          sudo curl -sLo /usr/local/bin/talisman https://github.com/thoughtworks/talisman/releases/download/v1.29.1/talisman_linux_amd64
+          sudo curl -sLo /usr/local/bin/talisman https://github.com/thoughtworks/talisman/releases/download/v1.32.0/talisman_linux_amd64
           sudo chmod 0755 /usr/local/bin/talisman
       - name: Install terraform-docs
         run: |
-          sudo sh -c 'curl -sL https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-linux-amd64.tar.gz | tar xzf - -C /usr/local/bin'
+          sudo sh -c 'curl -sL https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-linux-amd64.tar.gz | tar xzf - -C /usr/local/bin'
           sudo chmod 0755 /usr/local/bin/terraform-docs
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - uses: pre-commit/action@v3.0.1
   hadolint:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,43 @@
-# TODO: @memes - remove unused plugins for project
----
 # spell-checker:disable
+---
 repos:
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.28.0
+    rev: v1.35.1
     hooks:
       - id: yamllint
         name: yamllint
         files: \.(yml|yaml|talismanrc)$
-        types: [file, yaml]
+        types:
+          - file
+          - yaml
         exclude: cloud-config\.ya?ml$
         entry: yamllint --strict
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.88.2
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
-        args: ['--args=--sort-by=required --hide=providers']
+        args:
+          - '--args=--sort-by=required --hide=providers'
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.1.0
+    hooks:
+      - id: conventional-pre-commit
+        stages:
+          - commit-msg
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: detect-private-key
       - id: end-of-file-fixer
+      - id: no-commit-to-branch
+        args:
+          - -b
+          - main
       - id: trailing-whitespace
   - repo: https://github.com/thoughtworks/talisman
-    rev: v1.29.4
+    rev: v1.32.0
     hooks:
       - id: talisman-commit

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,7 @@
 ---
+version: ""
 fileignoreconfig:
 - filename: .github/workflows/release.yml
   checksum: f24e2cc79272f17b4732058956e6b8241cb4ae61655e75a1bd8ef8a04beabdde
 - filename: outputs.tf
-  checksum: 91e0de5c25e1488de0016463ad674cd80004b22ee0c0155ca66bf7f582acad27
+  checksum: cb8cd4b1c955888b5677c1c2d3ac312baeb8a9d4a773769fe21873bd21d40541

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "yaml.schemas": {
+        "https://json.schemastore.org/github-issue-config.json": ".github/ISSUE_TEMPLATE/config.yml"
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-<!-- markdownlint-disable MD024 -->
+<!-- markdownlint-disable MD004 MD012 MD024 -->
 
 All notable changes to this project will be documented in this file.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,26 +6,29 @@ contributors.
 ## Open an issue and pull request for changes
 
 All submissions, including those from project members, are required to go through
-review. We use GitHub Pull Requests for this workflow, which should be linked with
-an issue for tracking purposes.
-See [GitHub](https://help.github.com/articles/about-pull-requests/) for more details.
+review. We use [GitHub Pull Requests](https://help.github.com/articles/about-pull-requests/)
+for this workflow, which should be linked with an issue for tracking purposes.
+A GitHub action will be run against your PR to ensure code standards have been
+applied.
 
-## Pre-Commit
+[pre-commit] is used to ensure that all files have consistent formatting and to
+avoid committing secrets.
 
-[Pre-commit](https://pre-commit.com/) is used to ensure that all files have
-consistent formatting and to avoid committing secrets. Please install and
-integrate the tool before pushing changes to GitHub.
-
-1. Install pre-commit in venv or globally: see [instructions](https://pre-commit.com/#installation)
+1. Install [pre-commit] in a virtual python environment or globally: see [instructions](https://pre-commit.com/#installation)
 2. Fork and clone this repo
 3. Install pre-commit hook to git
 
    E.g.
 
    ```shell
-   pip install pre-commit
-   pre-commit install
+   pip install -r requirements-dev.txt
+   pre-commit install --hook-type commit-msg --hook-type pre-commit
    ```
 
-The hook will ensure that `pre-commit` will be run against all staged changes
-during `git commit`.
+4. Create a new branch for changes
+5. Commit and push changes for PR
+
+   The hook will ensure that `pre-commit` will be run against all staged changes
+   during `git commit`.
+
+[pre-commit]: https://pre-commit.com/

--- a/README.md
+++ b/README.md
@@ -4,17 +4,16 @@
 ![Maintenance](https://img.shields.io/maintenance/yes/2024)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
-This module implements a wrapper around Google's published bastion module that
-allows it to function correctly when deployed in a private VPC without public
-internet access, by pulling a container image containing a forward-proxy from a
-Google Artifact or Container Registry.
+This module deploys a bastion VM that can function correctly when deployed in a
+private VPC without public internet access, by pulling a container image
+containing a forward-proxy from a Google Artifact or Container Registry.
 
 As such, the scope of services this module provides is restricted to
 
 * An IAP protected forward-proxy deployed from Container Registry or Artifact Registry
 * An IAP protected SSH login
 * An optional set of Firewall Rules to allow bastion to connect to other GCP
-  resources specified as destination CIDRs, target service accounts, or target tags
+  resources specified as destination CIDRs or target service accounts
 
 > NOTE: This module is opinionated and deliberately inflexible; the Google
 > [bastion-host](https://registry.terraform.io/modules/terraform-google-modules/bastion-host/google/latest)
@@ -53,25 +52,23 @@ the container as needed.
 
     > NOTE: It is recommended to include `bastion_targets` to ensure GCP Firewall
     > rules are created to allow bastion => other resource traffic. Just add the
-    > target tags, service accounts, or CIDRs to the input. If you leave
+    > target service accounts, or CIDRs to the input. If you leave
     > `bastion_targets` at the default value, you will need to create bastion to
     > resource firewall rules outside of this module.
 
     ```hcl
-    prefix                = "example"
+    name                  = "example"
     project_id            = "my-project-id"
     zone                  = "us-west1-c"
     subnet                = "https://www.googleapis.com/compute/v1/projects/my-project-id/regions/us-west1/subnetworks/my-subnet"
 
     # This needs to point to your private repo copy of forward-proxy
-    proxy_container_image = "us-docker.pkg.dev/my-project-id/f5-automation-factory-container/forward-proxy:my-build"
+    proxy_container_image = "us-docker.pkg.dev/my-project-id/forward-proxy:my-build"
 
-    # Allow the bastion to connect to any VM tagged 'bastion-ok' and to the GKE
-    # master nodes at 172.19.0.0/28
+    # Allow the bastion to connect to GKE master nodes at 172.19.0.0/28
     bastion_targets       = {
         service_accounts = null
         cidrs            = ["172.19.0.0/28"]
-        tags             = ["bastion-ok"]
         priority         = null
     }
     ```
@@ -167,48 +164,51 @@ as you have authenticated to the target repository.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.8.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_bastion"></a> [bastion](#module\_bastion) | terraform-google-modules/bastion-host/google | 5.3.0 |
+No modules.
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [google-beta_google_artifact_registry_repository_iam_member.bastion](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_artifact_registry_repository_iam_member) | resource |
+| [google_artifact_registry_repository_iam_member.bastion](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
 | [google_compute_firewall.bastion_cidrs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.bastion_service_accounts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
-| [google_compute_firewall.bastion_tags](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.iap](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_instance.bastion](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | resource |
+| [google_iap_tunnel_instance_iam_binding.members](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iap_tunnel_instance_iam_binding) | resource |
+| [google_project_iam_member.bastion](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.bastion](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_binding.members](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_storage_bucket_iam_member.bastion](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
-| [google_compute_instance.bastion](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance) | data source |
+| [google_compute_image.disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 | [google_compute_subnetwork.subnet](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix to use when naming resources managed by this module. Must be RFC1035<br>compliant and between 5 and 30 characters in length, inclusive. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name to use when creating resources managed by this module. Must be RFC1035 compliant and between 5 and 30 characters in length, inclusive. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project identifier where the bastion instance will be deployed. | `string` | n/a | yes |
 | <a name="input_proxy_container_image"></a> [proxy\_container\_image](#input\_proxy\_container\_image) | The qualified container image to use as a forward-proxy through this bastion.<br>You must supply this value with a valid private Artifact or Container Repository<br>identifier, or a public repo identifier. | `string` | n/a | yes |
 | <a name="input_subnet"></a> [subnet](#input\_subnet) | The fully-qualified subnetwork self-link to which the bastion instance will be<br>attached. | `string` | n/a | yes |
 | <a name="input_zone"></a> [zone](#input\_zone) | The compute zone where where the bastion instance will be deployed. | `string` | n/a | yes |
-| <a name="input_additional_ports"></a> [additional\_ports](#input\_additional\_ports) | A list of additional TCP ports that will be allowed to receive IAP tunneled<br>traffic, in addition to the forward-proxy listener port (see `remote_port`).<br>Default is an empty list. | `list(number)` | `[]` | no |
-| <a name="input_bastion_targets"></a> [bastion\_targets](#input\_bastion\_targets) | An optional set of firewall targets that will be used to create GCP Firewall Rules<br>that allow the targets to receive _ALL_ ingress traffic from the bastion instance.<br>Targets are specified as a list of service account emails, destination CIDRs, and<br>target network tags. If a priority is unspecified, the rules will be created at<br>the default priority (1000).<br><br>Leave this variable at the default empty value to manage firewall rules outside<br>this module. | <pre>object({<br>    service_accounts = list(string)<br>    cidrs            = list(string)<br>    tags             = list(string)<br>    priority         = number<br>  })</pre> | <pre>{<br>  "cidrs": null,<br>  "priority": null,<br>  "service_accounts": null,<br>  "tags": null<br>}</pre> | no |
+| <a name="input_additional_bastion_roles"></a> [additional\_bastion\_roles](#input\_additional\_bastion\_roles) | An optional list of roles that will be assigned to the generated bastion service<br>account in addition to the standard logging, metrics, and OS Login roles. Default<br>is an empty list. | `list(string)` | `[]` | no |
+| <a name="input_additional_ports"></a> [additional\_ports](#input\_additional\_ports) | A list of additional TCP ports that will be allowed to receive IAP tunneled<br>traffic, in addition to the forward-proxy listener port (see `remote_port`) and SSH.<br>Default is an empty list. | `list(number)` | `[]` | no |
+| <a name="input_bastion_targets"></a> [bastion\_targets](#input\_bastion\_targets) | An optional set of firewall targets that will be used to create GCP Firewall Rules<br>that allow the targets to receive _ALL_ ingress traffic from the bastion instance.<br>Targets are specified as a list of service account emails and  destination CIDRs.<br>If a priority is unspecified, the rules will be created at the default priority (1000).<br><br>Leave this variable at the default empty value to manage firewall rules outside<br>this module. | <pre>object({<br>    service_accounts = list(string)<br>    cidrs            = list(string)<br>    priority         = number<br>  })</pre> | <pre>{<br>  "cidrs": null,<br>  "priority": null,<br>  "service_accounts": null<br>}</pre> | no |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | The size of the bastion boot disk in GB. Default is 20. | `number` | `20` | no |
 | <a name="input_external_ip"></a> [external\_ip](#input\_external\_ip) | Boolean flag to toggle provisioning of an ephemeral public IP on the bastion<br>instance; default is false. | `bool` | `false` | no |
 | <a name="input_image"></a> [image](#input\_image) | Specifies the image family and project id to use for bastion. Default will launch<br>the latest stable COS image with Confidential VM support. | <pre>object({<br>    family     = string<br>    project_id = string<br>  })</pre> | <pre>{<br>  "family": "cos-stable",<br>  "project_id": "confidential-vm-images"<br>}</pre> | no |
-| <a name="input_labels"></a> [labels](#input\_labels) | An optional map of labels to apply to resources created by this module, in addition<br>to those always set. Default is empty. | `map(string)` | `{}` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | An optional map of labels to apply to resources created by this module. Default is empty. | `map(string)` | `{}` | no |
 | <a name="input_local_port"></a> [local\_port](#input\_local\_port) | The local TCP port that will be embedded in the IAP tunnel command output. This<br>is the value to which HTTP/HTTPS proxies should use; e.g. HTTP\_PROXY=http://localhost:LOCAL_PORT,<br>where LOCAL\_PORT is the value of `local_port` variable. Default value is 8888. | `number` | `8888` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The Compute Engine machine type to use for bastion. Default is 'e2-medium'. | `string` | `"e2-medium"` | no |
 | <a name="input_members"></a> [members](#input\_members) | An optional list of user/group/serviceAccount emails that will be added as IAP<br>members for _this_ bastion. Default is empty. | `list(string)` | `[]` | no |
 | <a name="input_remote_port"></a> [remote\_port](#input\_remote\_port) | The remote TCP port that the forward-proxy container will be listening on.<br>Default value is 8888. | `number` | `8888` | no |
-| <a name="input_service_account_roles_supplemental"></a> [service\_account\_roles\_supplemental](#input\_service\_account\_roles\_supplemental) | An optional list of roles that will be assigned to the generated bastion service<br>account in addition to the standard logging, metrics, and OS Login roles. Default<br>is an empty list. | `list(string)` | `[]` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | An optional list of network tags to apply to resources created by this module,<br>in addition to those always set. Default is empty. | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | An optional list of network tags to apply to resources created by this module. Default is empty. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/containers/forward-proxy/Dockerfile
+++ b/containers/forward-proxy/Dockerfile
@@ -1,8 +1,8 @@
 # Run tinyproxy in forward only mode
-FROM alpine:3.17.2
+FROM alpine:3.19.1
 LABEL maintainer="Matthew Emes <memes@matthewemes.com>"
 
-RUN apk --no-cache add tinyproxy=1.11.1-r2
+RUN apk --no-cache add tinyproxy=1.11.1-r3 ca-certificates-bundle=20230506-r0
 EXPOSE 8888
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
 USER nobody

--- a/examples/quick-start/README.md
+++ b/examples/quick-start/README.md
@@ -20,20 +20,18 @@
 3. Create a `terraform.tfvars` file
 
     ```hcl
-    prefix                = "example"
+    name                  = "example"
     project_id            = "my-project-id"
     zone                  = "us-west1-c"
     subnet                = "https://www.googleapis.com/compute/v1/projects/my-project-id/regions/us-west1/subnetworks/my-subnet"
 
     # This needs to point to your private repo copy of forward-proxy
-    proxy_container_image = "us-docker.pkg.dev/my-project-id/f5-automation-factory-container/forward-proxy:my-build"
+    proxy_container_image = "us-docker.pkg.dev/my-project-id/forward-proxy:my-build"
 
-    # Allow the bastion to connect to any VM tagged 'bastion-ok' and to the GKE
-    # master nodes at 172.19.0.0/28
+    # Allow the bastion to connect to the GKE master nodes at 172.19.0.0/28
     bastion_targets       = {
         service_accounts = null
         cidrs            = ["172.19.0.0/28"]
-        tags             = ["bastion-ok"]
         priority         = null
     }
     ```
@@ -99,9 +97,9 @@ module "bastion" {
     source                = "memes/private-bastion/google"
     version               = "1.0.0"
     ephemeral_ip          = true
-    proxy_container_image = "ghcr.io/memes/terraform-google-private-bastion/forward-proxy:v2.3.4"
+    proxy_container_image = "ghcr.io/memes/terraform-google-private-bastion/forward-proxy:v3.0.0"
     # Other fields remain the same
-    prefix                = var.prefix
+    name                  = var.name
     project_id            = var.project_id
     zone                  = var.zone
     subnet                = var.subnet
@@ -121,14 +119,14 @@ external traffic through the NAT then a pull from Docker Hub or GHCR will work.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.8.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_bastion"></a> [bastion](#module\_bastion) | memes/private-bastion/google | 2.3.4 |
+| <a name="module_bastion"></a> [bastion](#module\_bastion) | memes/private-bastion/google | 3.0.0 |
 
 ## Resources
 
@@ -142,11 +140,10 @@ No resources.
 | <a name="input_proxy_container_image"></a> [proxy\_container\_image](#input\_proxy\_container\_image) | The qualified container image to use as a forward-proxy through this bastion. | `string` | n/a | yes |
 | <a name="input_subnet"></a> [subnet](#input\_subnet) | The fully-qualified subnetwork self-link to which the bastion instance will be<br>attached. | `string` | n/a | yes |
 | <a name="input_zone"></a> [zone](#input\_zone) | The compute zone where where the bastion instance will be deployed. | `string` | n/a | yes |
-| <a name="input_bastion_targets"></a> [bastion\_targets](#input\_bastion\_targets) | An optional set of firewall targets that will be used to create GCP Firewall Rules<br>that allow the targets to receive _ALL_ ingress traffic from the bastion instance.<br>Targets are specified as a list of service account emails, destination CIDRs, and<br>target network tags. If a priority is unspecified, the rules will be created at<br>the default priority (1000).<br><br>Leave this variable at the default empty value to manage firewall rules outside<br>this module. | <pre>object({<br>    service_accounts = list(string)<br>    cidrs            = list(string)<br>    tags             = list(string)<br>    priority         = number<br>  })</pre> | <pre>{<br>  "cidrs": null,<br>  "priority": null,<br>  "service_accounts": null,<br>  "tags": null<br>}</pre> | no |
-| <a name="input_labels"></a> [labels](#input\_labels) | An optional map of labels to apply to resources created by this module, in addition<br>to those always set. Default is empty. | `map(string)` | `{}` | no |
-| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix to use when naming resources managed by this module. Must be RFC1035<br>compliant and between 5 and 29 characters in length, inclusive. | `string` | `"example-public-repo"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | An optional list of network tags to apply to resources created by this module,<br>in addition to those always set. Default is empty. | `list(string)` | `[]` | no |
-| <a name="input_tf_service_account"></a> [tf\_service\_account](#input\_tf\_service\_account) | An optional service account email that the Google provider will be configured to<br>impersonate. | `string` | `null` | no |
+| <a name="input_bastion_targets"></a> [bastion\_targets](#input\_bastion\_targets) | An optional set of firewall targets that will be used to create GCP Firewall Rules<br>that allow the targets to receive _ALL_ ingress traffic from the bastion instance.<br>Targets are specified as a list of service account emails, destination CIDRs, and<br>target network tags. If a priority is unspecified, the rules will be created at<br>the default priority (1000).<br><br>Leave this variable at the default empty value to manage firewall rules outside<br>this module. | <pre>object({<br>    service_accounts = list(string)<br>    cidrs            = list(string)<br>    priority         = number<br>  })</pre> | <pre>{<br>  "cidrs": null,<br>  "priority": null,<br>  "service_accounts": null<br>}</pre> | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | An optional map of labels to apply to resources created by this module. Default is empty. | `map(string)` | `{}` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name to use when naming resources managed by this module. Must be RFC1035<br>compliant and between 5 and 29 characters in length, inclusive. | `string` | `"example-bastion"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | An optional list of network tags to apply to resources created by this module. Default is empty. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/examples/quick-start/main.tf
+++ b/examples/quick-start/main.tf
@@ -1,27 +1,27 @@
 terraform {
-  required_version = ">= 0.14.5"
+  required_version = ">= 1.2"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.8.0"
+      version = ">= 5.0"
     }
   }
 }
 
-# Use service account impersonation if a service account email has been provided
-provider "google" {
-  impersonate_service_account = var.tf_service_account
-}
-
 module "bastion" {
   source                = "memes/private-bastion/google"
-  version               = "2.3.4"
+  version               = "3.0.0"
   proxy_container_image = var.proxy_container_image
-  prefix                = var.prefix
+  name                  = var.name
   project_id            = var.project_id
   zone                  = var.zone
   subnet                = var.subnet
   labels                = var.labels
   tags                  = var.tags
-  bastion_targets       = var.bastion_targets
+  external_ip           = true
+  bastion_targets = {
+    service_accounts = ["f5-bigip-welcome-mollusk@f5-gcs-4138-sales-cloud-sales.iam.gserviceaccount.com"]
+    cidrs            = null
+    priority         = null
+  }
 }

--- a/examples/quick-start/variables.tf
+++ b/examples/quick-start/variables.tf
@@ -1,18 +1,10 @@
 # Common variables
-variable "tf_service_account" {
-  type        = string
-  default     = null
-  description = <<-EOD
-An optional service account email that the Google provider will be configured to
-impersonate.
-EOD
-}
 
-variable "prefix" {
+variable "name" {
   type        = string
-  default     = "example-public-repo"
+  default     = "example-bastion"
   description = <<-EOD
-The prefix to use when naming resources managed by this module. Must be RFC1035
+The name to use when naming resources managed by this module. Must be RFC1035
 compliant and between 5 and 29 characters in length, inclusive.
 EOD
 }
@@ -43,8 +35,7 @@ variable "labels" {
   type        = map(string)
   default     = {}
   description = <<-EOD
-An optional map of labels to apply to resources created by this module, in addition
-to those always set. Default is empty.
+An optional map of labels to apply to resources created by this module. Default is empty.
 EOD
 }
 
@@ -52,8 +43,7 @@ variable "tags" {
   type        = list(string)
   default     = []
   description = <<-EOD
-An optional list of network tags to apply to resources created by this module,
-in addition to those always set. Default is empty.
+An optional list of network tags to apply to resources created by this module. Default is empty.
 EOD
 }
 
@@ -68,13 +58,11 @@ variable "bastion_targets" {
   type = object({
     service_accounts = list(string)
     cidrs            = list(string)
-    tags             = list(string)
     priority         = number
   })
   default = {
     service_accounts = null
     cidrs            = null
-    tags             = null
     priority         = null
   }
   description = <<-EOD

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,12 @@
 output "ssh_command" {
-  value       = format("gcloud compute ssh %s --tunnel-through-iap --strict-host-key-checking=no --ssh-flag=-oUserKnownHostsFile=/dev/null --ssh-flag=-A --project=%s --zone=%s", module.bastion.hostname, var.project_id, var.zone)
+  value       = format("gcloud compute ssh %s --tunnel-through-iap --strict-host-key-checking=no --ssh-flag=-oUserKnownHostsFile=/dev/null --ssh-flag=-A --project=%s --zone=%s", google_compute_instance.bastion.name, var.project_id, var.zone)
   description = <<-EOD
 A gcloud command that will SSH via IAP to bastion host.
 EOD
 }
 
 output "tunnel_command" {
-  value       = format("gcloud compute start-iap-tunnel %s %d --local-host-port localhost:%d --project=%s --zone=%s", module.bastion.hostname, var.remote_port, var.local_port, var.project_id, var.zone)
+  value       = format("gcloud compute start-iap-tunnel %s %d --local-host-port localhost:%d --project=%s --zone=%s", google_compute_instance.bastion.name, var.remote_port, var.local_port, var.project_id, var.zone)
   description = <<-EOD
 A gcloud command that create a tunnel between localhost and bastion via IAP;
 connections to localhost:PORT will be tunneled to bastion forward-proxy. The value
@@ -15,33 +15,28 @@ EOD
 }
 
 output "ip_address" {
-  value       = module.bastion.ip_address
+  value       = google_compute_instance.bastion.network_interface[0].network_ip
   description = <<-EOD
 The private IP address of the bastion instance.
 EOD
 }
 
 output "self_link" {
-  value       = module.bastion.self_link
+  value       = google_compute_instance.bastion.self_link
   description = <<-EOD
 The self-link of the bastion instance.
 EOD
 }
 
-data "google_compute_instance" "bastion" {
-  count     = var.external_ip ? 1 : 0
-  self_link = module.bastion.self_link
-}
-
 output "public_ip_address" {
-  value       = try(data.google_compute_instance.bastion[0].network_interface[0].access_config[0].nat_ip, "")
+  value       = try(google_compute_instance.bastion.network_interface[0].access_config[0].nat_ip, "")
   description = <<-EOD
 The public IP address of the bastion, if applicable.
 EOD
 }
 
 output "service_account" {
-  value       = module.bastion.service_account
+  value       = google_service_account.bastion.email
   description = <<-EOD
 The service account created for the bastion.
 EOD

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Python requirements for hacking on this repo
+pre-commit==3.6.2
+-r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# Python requirements for this repo

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,20 @@
-variable "prefix" {
-  type = string
+variable "name" {
+  type     = string
+  nullable = false
   validation {
     # This value drives multiple derivative resource names and id's; the maximum
     # length permitted is limited by service account to 30 chars.
-    condition     = can(regex("^[a-z](?:[a-z0-9-]{4,28}[a-z0-9])$", var.prefix))
-    error_message = "The prefix variable must be RFC1035 compliant and between 5 and 30 characters in length."
+    condition     = can(regex("^[a-z](?:[a-z0-9-]{4,28}[a-z0-9])$", var.name))
+    error_message = "The name variable must be RFC1035 compliant and between 5 and 30 characters in length."
   }
   description = <<-EOD
-The prefix to use when naming resources managed by this module. Must be RFC1035
-compliant and between 5 and 30 characters in length, inclusive.
+The name to use when creating resources managed by this module. Must be RFC1035 compliant and between 5 and 30 characters in length, inclusive.
 EOD
 }
 
 variable "project_id" {
-  type = string
+  type     = string
+  nullable = false
   validation {
     condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
     error_message = "The project_id variable must must be 6 to 30 lowercase letters, digits, or hyphens; it must start with a letter and cannot end with a hyphen."
@@ -24,7 +25,8 @@ EOD
 }
 
 variable "zone" {
-  type = string
+  type     = string
+  nullable = false
   validation {
     condition     = can(regex("^[a-z]{2,20}-[a-z]{4,20}[0-9]-[a-z]$", var.zone))
     error_message = "At compute engine zone must be specified, and each zone must be a valid GCE zone name."
@@ -35,7 +37,8 @@ EOD
 }
 
 variable "subnet" {
-  type = string
+  type     = string
+  nullable = false
   validation {
     condition     = can(regex("^(?:https://www\\.googleapis\\.com/compute/v1/)?projects/[a-z][a-z0-9-]{4,28}[a-z0-9]/regions/[a-z][a-z-]+[0-9]/subnetworks/[a-z]([a-z0-9-]{0,61}[a-z0-9])?$", var.subnet))
     error_message = "Subnet variable must contain a fully-qualified subnet self-link."
@@ -51,6 +54,7 @@ variable "image" {
     family     = string
     project_id = string
   })
+  nullable = false
   validation {
     condition     = coalesce(var.image.project_id, "unspecified") != "unspecified" && can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.image.project_id)) && coalesce(var.image.family, "unspecified") != "unspecified" && can(regex("^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$", var.image.family))
     error_message = "The image variable must contain a valid project_id and family name."
@@ -68,6 +72,7 @@ EOD
 
 variable "external_ip" {
   type        = bool
+  nullable    = false
   default     = false
   description = <<-EOD
 Boolean flag to toggle provisioning of an ephemeral public IP on the bastion
@@ -77,24 +82,25 @@ EOD
 
 variable "labels" {
   type        = map(string)
+  nullable    = false
   default     = {}
   description = <<-EOD
-An optional map of labels to apply to resources created by this module, in addition
-to those always set. Default is empty.
+An optional map of labels to apply to resources created by this module. Default is empty.
 EOD
 }
 
 variable "tags" {
   type        = list(string)
+  nullable    = false
   default     = []
   description = <<-EOD
-An optional list of network tags to apply to resources created by this module,
-in addition to those always set. Default is empty.
+An optional list of network tags to apply to resources created by this module. Default is empty.
 EOD
 }
 
 variable "proxy_container_image" {
   type        = string
+  nullable    = false
   description = <<-EOD
 The qualified container image to use as a forward-proxy through this bastion.
 You must supply this value with a valid private Artifact or Container Repository
@@ -106,21 +112,19 @@ variable "bastion_targets" {
   type = object({
     service_accounts = list(string)
     cidrs            = list(string)
-    tags             = list(string)
     priority         = number
   })
+  nullable = false
   default = {
     service_accounts = null
     cidrs            = null
-    tags             = null
     priority         = null
   }
   description = <<-EOD
 An optional set of firewall targets that will be used to create GCP Firewall Rules
 that allow the targets to receive _ALL_ ingress traffic from the bastion instance.
-Targets are specified as a list of service account emails, destination CIDRs, and
-target network tags. If a priority is unspecified, the rules will be created at
-the default priority (1000).
+Targets are specified as a list of service account emails and  destination CIDRs.
+If a priority is unspecified, the rules will be created at the default priority (1000).
 
 Leave this variable at the default empty value to manage firewall rules outside
 this module.
@@ -128,7 +132,8 @@ EOD
 }
 
 variable "additional_ports" {
-  type = list(number)
+  type     = list(number)
+  nullable = false
   validation {
     condition     = length(join("", [for port in var.additional_ports : port > 0 && port < 65536 && port == floor(port) ? "x" : ""])) == length(var.additional_ports)
     error_message = "Each additional_port must be an integer between 1 and 65535 inclusive."
@@ -136,13 +141,14 @@ variable "additional_ports" {
   default     = []
   description = <<-EOD
 A list of additional TCP ports that will be allowed to receive IAP tunneled
-traffic, in addition to the forward-proxy listener port (see `remote_port`).
+traffic, in addition to the forward-proxy listener port (see `remote_port`) and SSH.
 Default is an empty list.
 EOD
 }
 
 variable "disk_size_gb" {
-  type = number
+  type     = number
+  nullable = false
   validation {
     condition     = tonumber(coalesce(var.disk_size_gb, "20")) >= 20
     error_message = "The disk_size_gb value must be empty or >= 20."
@@ -155,6 +161,7 @@ EOD
 
 variable "machine_type" {
   type        = string
+  nullable    = false
   default     = "e2-medium"
   description = <<-EOD
 The Compute Engine machine type to use for bastion. Default is 'e2-medium'.
@@ -163,6 +170,7 @@ EOD
 
 variable "members" {
   type        = list(string)
+  nullable    = false
   default     = []
   description = <<-EOD
 An optional list of user/group/serviceAccount emails that will be added as IAP
@@ -170,8 +178,9 @@ members for _this_ bastion. Default is empty.
 EOD
 }
 
-variable "service_account_roles_supplemental" {
+variable "additional_bastion_roles" {
   type        = list(string)
+  nullable    = false
   default     = []
   description = <<-EOD
 An optional list of roles that will be assigned to the generated bastion service
@@ -181,7 +190,8 @@ EOD
 }
 
 variable "remote_port" {
-  type = number
+  type     = number
+  nullable = false
   validation {
     condition     = var.remote_port > 0 && var.remote_port < 65536 && var.remote_port == floor(var.remote_port)
     error_message = "The remote_port value must be an integer between 1 and 65535 inclusive."
@@ -194,7 +204,8 @@ EOD
 }
 
 variable "local_port" {
-  type = number
+  type     = number
+  nullable = false
   validation {
     condition     = var.local_port > 0 && var.local_port < 65536 && var.local_port == floor(var.local_port)
     error_message = "The local_port value must be an integer between 1 and 65535 inclusive."


### PR DESCRIPTION
Prefer a simpler route to creating bastion instances directly from a `google_compute_instance` declaration.