### PR TITLE
fix: Update tinyproxy for CVE mitigation

### DIFF
--- a/containers/forward-proxy/Dockerfile
+++ b/containers/forward-proxy/Dockerfile
@@ -1,8 +1,8 @@
 # Run tinyproxy in forward only mode
-FROM alpine:3.19.1
+FROM alpine:3.20.0
 LABEL maintainer="Matthew Emes <memes@matthewemes.com>"
 
-RUN apk --no-cache add tinyproxy=1.11.1-r3 ca-certificates-bundle=20230506-r0
+RUN apk --no-cache add tinyproxy=1.11.2-r0 ca-certificates-bundle=20240226-r0
 EXPOSE 8888
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
 USER nobody


### PR DESCRIPTION
Update the forward-proxy container to be based on Alpine 3.20.0, and use new versions for ca-certificates-bundle and tinyproxy. Tinyproxy v1.11.2 addresses CVE-2023-49606.

Closes #533