### PR TITLE
Automatic ingress firewall when using external IP

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,7 +26,7 @@ jobs:
           sudo chmod 0755 /usr/local/bin/talisman
       - name: Install terraform-docs
         run: |
-          sudo sh -c 'curl -sL https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-linux-amd64.tar.gz | tar xzf - -C /usr/local/bin'
+          sudo sh -c 'curl -sL https://github.com/terraform-docs/terraform-docs/releases/download/v0.18.0/terraform-docs-v0.18.0-linux-amd64.tar.gz | tar xzf - -C /usr/local/bin'
           sudo chmod 0755 /usr/local/bin/terraform-docs
       - uses: actions/setup-python@v5
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,20 +13,20 @@ repos:
         exclude: cloud-config\.ya?ml$
         entry: yamllint --strict
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.2
+    rev: v1.92.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
         args:
           - '--args=--sort-by=required --hide=providers'
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.1.0
+    rev: v3.4.0
     hooks:
       - id: conventional-pre-commit
         stages:
           - commit-msg
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@
 pre-release.%:
 	@echo '$*' | grep -Eq '^v(?:[0-9]+\.){2}[0-9]+$$' || \
 		(echo "Tag doesn't meet requirements"; exit 1)
-	@test "$(shell git status --porcelain | wc -l | grep -Eo '[0-9]+')" == "0" || \
-		(echo "Git tree is unclean"; exit 1)
 	@find examples -type f -name main.tf -print0 | \
 		xargs -0 awk 'BEGIN{m=0;s=0;v=0}; /module "bastion"/ {m=1}; m==1 && /source[ \t]*=[ \t]*"memes\/private-bastion\/google/ {s++}; m==1 && /version[ \t]*=[ \t]*"$(subst .,\.,$(*:v%=%))"/ {v=1}; END{if (s==0) { printf "%s has incorrect source", FILENAME}; if (v==0) { printf "%s has incorrect version\n", FILENAME}; if (s==0 || v==0) { exit 1}}'
+	@test "$(shell git status --porcelain | wc -l | grep -Eo '[0-9]+')" == "0" || \
+		(echo "Git tree is unclean"; exit 1)
 	@echo 'Source is ready to release $*'

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_artifact_registry_repository_iam_member.bastion](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
+| [google_compute_firewall.access_bastion](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.bastion_cidrs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.bastion_service_accounts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.iap](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
@@ -208,6 +209,7 @@ No modules.
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The Compute Engine machine type to use for bastion. Default is 'e2-medium'. | `string` | `"e2-medium"` | no |
 | <a name="input_members"></a> [members](#input\_members) | An optional list of user/group/serviceAccount emails that will be added as IAP<br>members for _this_ bastion. Default is empty. | `list(string)` | `[]` | no |
 | <a name="input_remote_port"></a> [remote\_port](#input\_remote\_port) | The remote TCP port that the forward-proxy container will be listening on.<br>Default value is 8888. | `number` | `8888` | no |
+| <a name="input_source_cidrs"></a> [source\_cidrs](#input\_source\_cidrs) | An optional list of CIDRs that will be permitted to access the bastion on ports 22 and `remote_port` (default 8888)<br>when the `external_ip` flag is set to true. | `list(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | An optional list of network tags to apply to resources created by this module. Default is empty. | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ No modules.
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The Compute Engine machine type to use for bastion. Default is 'e2-medium'. | `string` | `"e2-medium"` | no |
 | <a name="input_members"></a> [members](#input\_members) | An optional list of user/group/serviceAccount emails that will be added as IAP<br>members for _this_ bastion. Default is empty. | `list(string)` | `[]` | no |
 | <a name="input_remote_port"></a> [remote\_port](#input\_remote\_port) | The remote TCP port that the forward-proxy container will be listening on.<br>Default value is 8888. | `number` | `8888` | no |
-| <a name="input_source_cidrs"></a> [source\_cidrs](#input\_source\_cidrs) | An optional list of CIDRs that will be permitted to access the bastion on ports 22 and `remote_port` (default 8888)<br>when the `external_ip` flag is set to true. | `list(string)` | `null` | no |
+| <a name="input_source_cidrs"></a> [source\_cidrs](#input\_source\_cidrs) | An optional list of CIDRs that will be permitted to access the bastion on ports 22, `remote_port` (default 8888), and<br>any listed in `additional_ports` directly via public IP when the `external_ip` flag is set to true. Default is an empty<br>list. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | An optional list of network tags to apply to resources created by this module. Default is empty. | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/containers/forward-proxy/Dockerfile
+++ b/containers/forward-proxy/Dockerfile
@@ -1,8 +1,8 @@
 # Run tinyproxy in forward only mode
-FROM alpine:3.20.0
+FROM alpine:3.20.2
 LABEL maintainer="Matthew Emes <memes@matthewemes.com>"
 
-RUN apk --no-cache add tinyproxy=1.11.2-r0 ca-certificates-bundle=20240226-r0
+RUN apk --no-cache add tinyproxy=1.11.2-r0 ca-certificates-bundle=20240705-r0
 EXPOSE 8888
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
 USER nobody

--- a/examples/quick-start/README.md
+++ b/examples/quick-start/README.md
@@ -95,9 +95,12 @@ For example, to pull from GitHub using a public IP address on the bastion:
 ```hcl
 module "bastion" {
     source                = "memes/private-bastion/google"
-    version               = "1.0.0"
+    version               = "3.1.0"
     ephemeral_ip          = true
-    proxy_container_image = "ghcr.io/memes/terraform-google-private-bastion/forward-proxy:v3.0.0"
+    proxy_container_image = "ghcr.io/memes/terraform-google-private-bastion/forward-proxy:v3.1.0"
+    source_cidrs = [
+        "1.2.3.4/32",
+    ]
     # Other fields remain the same
     name                  = var.name
     project_id            = var.project_id
@@ -111,7 +114,8 @@ module "bastion" {
 
 Of course, if there is a NAT gateway on the VPC network, or other NAT egress
 solution such as BIG-IP, as long as the VPC routes have a default that directs
-external traffic through the NAT then a pull from Docker Hub or GHCR will work.
+external traffic through the NAT then a pull from Docker Hub or GHCR will work
+without requiring an external_ip.
 
 <!-- markdownlint-disable no-inline-html no-bare-urls -->
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -126,7 +130,7 @@ external traffic through the NAT then a pull from Docker Hub or GHCR will work.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_bastion"></a> [bastion](#module\_bastion) | memes/private-bastion/google | 3.0.1 |
+| <a name="module_bastion"></a> [bastion](#module\_bastion) | memes/private-bastion/google | 3.1.0 |
 
 ## Resources
 

--- a/examples/quick-start/main.tf
+++ b/examples/quick-start/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 module "bastion" {
   source                = "memes/private-bastion/google"
-  version               = "3.0.1"
+  version               = "3.1.0"
   proxy_container_image = var.proxy_container_image
   name                  = var.name
   project_id            = var.project_id
@@ -18,10 +18,6 @@ module "bastion" {
   subnet                = var.subnet
   labels                = var.labels
   tags                  = var.tags
-  external_ip           = true
-  bastion_targets = {
-    service_accounts = ["f5-bigip-welcome-mollusk@f5-gcs-4138-sales-cloud-sales.iam.gserviceaccount.com"]
-    cidrs            = null
-    priority         = null
-  }
+  external_ip           = false
+  bastion_targets       = var.bastion_targets
 }

--- a/main.tf
+++ b/main.tf
@@ -202,9 +202,6 @@ resource "google_compute_firewall" "access_bastion" {
   ]
   allow {
     protocol = "TCP"
-    ports = [
-      22,
-      var.remote_port,
-    ]
+    ports    = concat([22], [var.remote_port], var.additional_ports)
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -186,3 +186,25 @@ resource "google_compute_firewall" "bastion_cidrs" {
     protocol = "all"
   }
 }
+
+# Allow access to the bastion instance on ports 22 and remote_port from the set of source CIDRs.
+resource "google_compute_firewall" "access_bastion" {
+  for_each      = var.external_ip && try(length(var.source_cidrs), 0) > 0 ? { format("%s-allow-public-ingress", var.name) = distinct(var.source_cidrs) } : {}
+  project       = var.project_id
+  name          = each.key
+  network       = data.google_compute_subnetwork.subnet.network
+  description   = format("Allow external access to public bastion (%s)", var.name)
+  direction     = "INGRESS"
+  priority      = 1000
+  source_ranges = each.value
+  target_service_accounts = [
+    google_service_account.bastion.email,
+  ]
+  allow {
+    protocol = "TCP"
+    ports = [
+      22,
+      var.remote_port,
+    ]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -217,3 +217,17 @@ is the value to which HTTP/HTTPS proxies should use; e.g. HTTP_PROXY=http://loca
 where LOCAL_PORT is the value of `local_port` variable. Default value is 8888.
 EOD
 }
+
+variable "source_cidrs" {
+  type     = list(string)
+  nullable = true
+  validation {
+    condition     = var.source_cidrs == null ? true : alltrue([for cidr in var.source_cidrs : can(cidrhost(cidr, 0))])
+    error_message = "Each source_cidrs value must be a valid IPv4 or IPv6 CIDR."
+  }
+  default     = null
+  description = <<-EOD
+An optional list of CIDRs that will be permitted to access the bastion on ports 22 and `remote_port` (default 8888)
+when the `external_ip` flag is set to true.
+EOD
+}

--- a/variables.tf
+++ b/variables.tf
@@ -220,14 +220,15 @@ EOD
 
 variable "source_cidrs" {
   type     = list(string)
-  nullable = true
+  nullable = false
   validation {
-    condition     = var.source_cidrs == null ? true : alltrue([for cidr in var.source_cidrs : can(cidrhost(cidr, 0))])
+    condition     = alltrue([for cidr in var.source_cidrs : can(cidrhost(cidr, 0))])
     error_message = "Each source_cidrs value must be a valid IPv4 or IPv6 CIDR."
   }
-  default     = null
+  default     = []
   description = <<-EOD
-An optional list of CIDRs that will be permitted to access the bastion on ports 22 and `remote_port` (default 8888)
-when the `external_ip` flag is set to true.
+An optional list of CIDRs that will be permitted to access the bastion on ports 22, `remote_port` (default 8888), and
+any listed in `additional_ports` directly via public IP when the `external_ip` flag is set to true. Default is an empty
+list.
 EOD
 }


### PR DESCRIPTION
Automatically add required firewall rule when `external_ip` is true and `source_cidrs` is not null or empty.

Closes #96 